### PR TITLE
Add meta tag to verify domain for GSuite

### DIFF
--- a/assets/html/base.html
+++ b/assets/html/base.html
@@ -8,6 +8,7 @@
 
     <link href="/css/bootstrap.min.css" rel="stylesheet">
     <link href="/css/main.css" rel="stylesheet">
+    <meta name="google-site-verification" content="9PI9MLvTpsSxy96ptsKHt2-FTV8ctIZhRzQ05YDALd4" />
 
     <!--[if lt IE 9]>
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>


### PR DESCRIPTION
Setting this up as a test account for GSuite admin.
We require a non Zapier domain so we can test the admin functionality for building a Google Groups app. Google requires that you verify that you own the domain.

*Here were the instructions from Google:*
Verify by adding a meta tag
Use this method if you can edit conspiracysanta.com's homepage HTML. You'll add a meta tag containing a verification code to your website. This won't affect your website or email.
Copy and paste the meta tag into your home page at http://conspiracysanta.com. Place the meta tag in the <head> section and before the <body> section of your homepage.

